### PR TITLE
Add docker-compose for local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,35 @@ mobile application and all backend microservices.
 
 Each service currently provides a simple FastAPI stub with a `/health` endpoint
 and a Dockerfile for containerization.
+
+## Running the stack locally
+
+This repository includes a `docker-compose.yml` file for spinning up all
+services along with a Postgres database. Docker and Docker Compose must be
+installed.
+
+1. From the repository root run:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+   The command builds the service images (if necessary) and starts the full
+   stack.
+
+2. Once running you can access the services on the following ports:
+
+   - **API Gateway:** <http://localhost:8000>
+   - **Context Service:** <http://localhost:8001>
+   - **LLM Gateway:** <http://localhost:8002>
+   - **TTS Service:** <http://localhost:8003>
+
+   Postgres is exposed on port `5432` with the default credentials
+   `betterbooks`/`betterbooks` and database name `betterbooks`.
+
+3. Stop the stack with `Ctrl+C` and remove containers with:
+
+   ```bash
+   docker-compose down
+   ```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: betterbooks
+      POSTGRES_PASSWORD: betterbooks
+      POSTGRES_DB: betterbooks
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  api_gateway:
+    build: ./services/api_gateway
+    environment:
+      CONTEXT_SERVICE_URL: http://context_service:8000
+      LLM_GATEWAY_URL: http://llm_gateway:8000
+      TTS_SERVICE_URL: http://tts_service:8000
+    depends_on:
+      - context_service
+      - llm_gateway
+      - tts_service
+    ports:
+      - "8000:8000"
+
+  context_service:
+    build: ./services/context_service
+    environment:
+      DATABASE_URL: postgres://betterbooks:betterbooks@postgres:5432/betterbooks
+    depends_on:
+      - postgres
+    ports:
+      - "8001:8000"
+
+  llm_gateway:
+    build: ./services/llm_gateway
+    ports:
+      - "8002:8000"
+
+  tts_service:
+    build: ./services/tts_service
+    ports:
+      - "8003:8000"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with Postgres and all backend services
- document how to run the stack locally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688310cff69483338ad5e27c2f0dc7ce