### PR TITLE
Add gRPC proto definitions

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,3 +1,22 @@
 # Protobuf Definitions
 
 Shared gRPC definitions for communication between services.
+
+## Generating Python stubs
+
+Install the gRPC tools once:
+
+```bash
+pip install grpcio grpcio-tools
+```
+
+From the repository root run:
+
+```bash
+python -m grpc_tools.protoc -I proto \
+    --python_out=proto --grpc_python_out=proto \
+    proto/*.proto
+```
+
+This will generate `*_pb2.py` and `*_pb2_grpc.py` files next to the `.proto`
+files which can be imported by the services.

--- a/proto/context_service.proto
+++ b/proto/context_service.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package betterbooks.context;
+
+service ContextService {
+  rpc GetContext (ContextRequest) returns (ContextResponse);
+}
+
+message ContextRequest {
+  string book_id = 1;
+  string query = 2;
+}
+
+message ContextResponse {
+  string context = 1;
+}

--- a/proto/llm_gateway.proto
+++ b/proto/llm_gateway.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package betterbooks.llm;
+
+service LLMGateway {
+  rpc GenerateText (GenerateRequest) returns (GenerateResponse);
+}
+
+message GenerateRequest {
+  string context = 1;
+}
+
+message GenerateResponse {
+  string text = 1;
+}

--- a/proto/tts_service.proto
+++ b/proto/tts_service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package betterbooks.tts;
+
+service TTSService {
+  rpc SynthesizeSpeech (SynthesizeRequest) returns (SynthesizeResponse);
+}
+
+message SynthesizeRequest {
+  string text = 1;
+}
+
+message SynthesizeResponse {
+  bytes audio = 1;
+}


### PR DESCRIPTION
## Summary
- define RPC interfaces for Context, LLM, and TTS services
- document how to generate python gRPC stubs

## Testing
- `python -m grpc_tools.protoc -I proto --python_out=/tmp --grpc_python_out=/tmp proto/context_service.proto proto/llm_gateway.proto proto/tts_service.proto` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688310ac88048333a3767e5d8086e073