### PR TITLE
Add backend service features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,4 @@ mobile application and all backend microservices.
 - `proto/` – gRPC/Protobuf definitions.
 - `infra/` – Terraform and Helm deployment configurations.
 
-Each service currently provides a simple FastAPI stub with a `/health` endpoint
-and a Dockerfile for containerization.
+Each service is a small FastAPI application packaged with a Dockerfile.

--- a/services/api_gateway/README.md
+++ b/services/api_gateway/README.md
@@ -1,8 +1,23 @@
 # API Gateway
 
-FastAPI application serving as the public REST API.
+FastAPI application serving as the public REST API and coordinating requests
+between the internal services.
 
 Run locally with:
 ```
 uvicorn main:app --reload
+```
+
+### Example
+
+```bash
+# Complete a prompt using the LLM
+curl -X POST localhost:8000/complete \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Tell me a joke"}'
+
+# Convert text to speech
+curl -X POST localhost:8000/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello"}'
 ```

--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -1,8 +1,42 @@
+import os
+
+import httpx
 from fastapi import FastAPI
+from pydantic import BaseModel
+
+CONTEXT_URL = os.getenv("CONTEXT_SERVICE_URL", "http://context_service:8000")
+LLM_URL = os.getenv("LLM_GATEWAY_URL", "http://llm_gateway:8000")
+TTS_URL = os.getenv("TTS_SERVICE_URL", "http://tts_service:8000")
 
 app = FastAPI()
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+class Prompt(BaseModel):
+    prompt: str
+
+
+class Text(BaseModel):
+    text: str
+
+
+@app.post("/complete")
+def complete(prompt: Prompt):
+    resp = httpx.post(f"{LLM_URL}/complete", json=prompt.dict())
+    return resp.json()
+
+
+@app.post("/tts")
+def tts(text: Text):
+    resp = httpx.post(f"{TTS_URL}/synthesize", json=text.dict())
+    return resp.json()
+
+
+@app.post("/context/search")
+def search_context(query: dict):
+    resp = httpx.post(f"{CONTEXT_URL}/search", json=query)
+    return resp.json()
 

--- a/services/api_gateway/requirements.txt
+++ b/services/api_gateway/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+httpx

--- a/services/context_service/README.md
+++ b/services/context_service/README.md
@@ -1,3 +1,26 @@
 # Context Service
 
-FastAPI service that retrieves book context from Postgres with pgvector.
+FastAPI service that stores and searches embeddings in Postgres using
+[`pgvector`](https://github.com/pgvector/pgvector).
+
+### Running
+
+```
+uvicorn main:app --reload
+```
+
+Set `DATABASE_URL` to point at your Postgres instance.
+
+### Example
+
+```bash
+# Store an embedding
+curl -X POST localhost:8000/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"id":"book1","embedding":[0.1,0.2,0.3]}'
+
+# Search for similar embeddings
+curl -X POST localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{"embedding":[0.1,0.2,0.3],"top_k":5}'
+```

--- a/services/context_service/main.py
+++ b/services/context_service/main.py
@@ -1,8 +1,67 @@
+import os
+from typing import List
+
+import psycopg
 from fastapi import FastAPI
+from pydantic import BaseModel
+from pgvector.psycopg import register_vector
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost/postgres")
+
+conn = psycopg.connect(DATABASE_URL)
+register_vector(conn)
+
+with conn.cursor() as cur:
+    cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS embeddings (
+            id TEXT PRIMARY KEY,
+            embedding vector(1536)
+        )
+        """
+    )
+    conn.commit()
 
 app = FastAPI()
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+class EmbeddingItem(BaseModel):
+    id: str
+    embedding: List[float]
+
+
+class SearchQuery(BaseModel):
+    embedding: List[float]
+    top_k: int = 5
+
+
+@app.post("/embeddings")
+def add_embedding(item: EmbeddingItem):
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO embeddings (id, embedding)
+            VALUES (%s, %s)
+            ON CONFLICT (id) DO UPDATE SET embedding = EXCLUDED.embedding
+            """,
+            (item.id, item.embedding),
+        )
+        conn.commit()
+    return {"status": "stored"}
+
+
+@app.post("/search")
+def search_embeddings(query: SearchQuery):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM embeddings ORDER BY embedding <-> %s LIMIT %s",
+            (query.embedding, query.top_k),
+        )
+        rows = cur.fetchall()
+    return {"ids": [r[0] for r in rows]}
 

--- a/services/llm_gateway/README.md
+++ b/services/llm_gateway/README.md
@@ -1,3 +1,19 @@
 # LLM Gateway
 
-Provides a single gRPC/HTTP interface to the chosen large language model.
+Provides a REST endpoint that proxies requests to the configured language model
+(OpenAI by default).
+
+### Running
+
+```
+export OPENAI_API_KEY=your-key
+uvicorn main:app --reload
+```
+
+### Example
+
+```bash
+curl -X POST localhost:8000/complete \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Once upon a time"}'
+```

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -1,8 +1,29 @@
+import os
+
+import openai
 from fastapi import FastAPI
+from pydantic import BaseModel
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI()
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+class CompletionRequest(BaseModel):
+    prompt: str
+    max_tokens: int = 50
+
+
+@app.post("/complete")
+def complete(req: CompletionRequest):
+    resp = openai.Completion.create(
+        model="text-davinci-003",
+        prompt=req.prompt,
+        max_tokens=req.max_tokens,
+    )
+    return {"text": resp.choices[0].text.strip()}
 

--- a/services/llm_gateway/requirements.txt
+++ b/services/llm_gateway/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+openai

--- a/services/tts_service/README.md
+++ b/services/tts_service/README.md
@@ -1,3 +1,17 @@
 # TTS Service
 
-Generates audio using Coqui TTS.
+Generates speech audio using [Coqui TTS](https://github.com/coqui-ai/TTS).
+
+### Running
+
+```
+uvicorn main:app --reload
+```
+
+### Example
+
+```bash
+curl -X POST localhost:8000/synthesize \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello world"}'
+```

--- a/services/tts_service/main.py
+++ b/services/tts_service/main.py
@@ -1,8 +1,33 @@
+import base64
+import os
+import tempfile
+
 from fastapi import FastAPI
+from pydantic import BaseModel
+from TTS.api import TTS
+
+MODEL_NAME = os.getenv("TTS_MODEL", "tts_models/en/ljspeech/tacotron2-DDC")
+tts = TTS(MODEL_NAME, progress_bar=False, gpu=False)
 
 app = FastAPI()
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+class SynthesisRequest(BaseModel):
+    text: str
+
+
+@app.post("/synthesize")
+def synthesize(req: SynthesisRequest):
+    wav = tts.tts(req.text)
+    fd, path = tempfile.mkstemp(suffix=".wav")
+    tts.save_wav(wav, path)
+    with open(path, "rb") as f:
+        data = base64.b64encode(f.read()).decode()
+    os.close(fd)
+    os.remove(path)
+    return {"audio": data}
 


### PR DESCRIPTION
## Summary
- connect context service to Postgres and expose embedding APIs
- add OpenAI-backed completion endpoint in llm gateway
- generate speech with Coqui TTS
- coordinate requests in api gateway
- document how to use each service

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688310a56be883338ff51dea47e7cd2e