### PR TITLE
Add Terraform modules and Helm charts

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,4 +1,32 @@
 # Infrastructure
 
-Infrastructure-as-Code for deploying the platform. Use Terraform for cloud
-resources and Helm for Kubernetes manifests.
+This directory contains the Terraform and Helm configurations used to deploy the
+BetterBooks platform.
+
+## Terraform
+
+Terraform provisions the AWS resources such as the EKS Kubernetes cluster and
+RDS database. Example usage:
+
+```bash
+cd terraform
+terraform init
+terraform apply
+```
+
+Set the necessary variables (e.g. `aws_region`, `subnet_ids`, credentials) via
+a `terraform.tfvars` file or environment variables before applying.
+
+## Helm
+
+Once the cluster is available, each service can be deployed using its Helm
+chart. From the `helm` directory run:
+
+```bash
+helm upgrade --install api-gateway ./api_gateway
+helm upgrade --install context-service ./context_service
+helm upgrade --install llm-gateway ./llm_gateway
+helm upgrade --install tts-service ./tts_service
+```
+
+Customise the image tags or other values with `--set` or a custom values file.

--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -1,1 +1,12 @@
-# Helm chart placeholder
+# Helm Charts
+
+This directory contains a Helm chart for each service in the platform. Each chart
+produces a Deployment and Service for running the containerized application on
+Kubernetes.
+
+Charts:
+
+- `api_gateway`
+- `context_service`
+- `llm_gateway`
+- `tts_service`

--- a/infra/helm/api_gateway/Chart.yaml
+++ b/infra/helm/api_gateway/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: api-gateway
+version: 0.1.0
+appVersion: "1.0"

--- a/infra/helm/api_gateway/templates/_helpers.tpl
+++ b/infra/helm/api_gateway/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "api-gateway.name" -}}
+api-gateway
+{{- end -}}
+
+{{- define "api-gateway.fullname" -}}
+{{ include "api-gateway.name" . }}
+{{- end -}}

--- a/infra/helm/api_gateway/templates/deployment.yaml
+++ b/infra/helm/api_gateway/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "api-gateway.fullname" . }}
+  labels:
+    app: {{ include "api-gateway.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "api-gateway.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "api-gateway.name" . }}
+    spec:
+      containers:
+        - name: api-gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8000
+          env:
+            - name: CONTEXT_SERVICE_URL
+              value: http://context-service:8000
+            - name: LLM_GATEWAY_URL
+              value: http://llm-gateway:8000
+            - name: TTS_SERVICE_URL
+              value: http://tts-service:8000

--- a/infra/helm/api_gateway/templates/service.yaml
+++ b/infra/helm/api_gateway/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "api-gateway.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+  selector:
+    app: {{ include "api-gateway.name" . }}

--- a/infra/helm/api_gateway/values.yaml
+++ b/infra/helm/api_gateway/values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: betterbooks/api-gateway
+  tag: latest
+service:
+  type: ClusterIP
+  port: 80

--- a/infra/helm/context_service/Chart.yaml
+++ b/infra/helm/context_service/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: context-service
+version: 0.1.0
+appVersion: "1.0"

--- a/infra/helm/context_service/templates/_helpers.tpl
+++ b/infra/helm/context_service/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "context-service.name" -}}
+context-service
+{{- end -}}
+
+{{- define "context-service.fullname" -}}
+{{ include "context-service.name" . }}
+{{- end -}}

--- a/infra/helm/context_service/templates/deployment.yaml
+++ b/infra/helm/context_service/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "context-service.fullname" . }}
+  labels:
+    app: {{ include "context-service.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "context-service.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "context-service.name" . }}
+    spec:
+      containers:
+        - name: context-service
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.databaseUrl | quote }}

--- a/infra/helm/context_service/templates/service.yaml
+++ b/infra/helm/context_service/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "context-service.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+  selector:
+    app: {{ include "context-service.name" . }}

--- a/infra/helm/context_service/values.yaml
+++ b/infra/helm/context_service/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: betterbooks/context-service
+  tag: latest
+service:
+  type: ClusterIP
+  port: 80
+databaseUrl: postgres://betterbooks:betterbooks@postgres:5432/betterbooks

--- a/infra/helm/llm_gateway/Chart.yaml
+++ b/infra/helm/llm_gateway/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: llm-gateway
+version: 0.1.0
+appVersion: "1.0"

--- a/infra/helm/llm_gateway/templates/_helpers.tpl
+++ b/infra/helm/llm_gateway/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "llm-gateway.name" -}}
+llm-gateway
+{{- end -}}
+
+{{- define "llm-gateway.fullname" -}}
+{{ include "llm-gateway.name" . }}
+{{- end -}}

--- a/infra/helm/llm_gateway/templates/deployment.yaml
+++ b/infra/helm/llm_gateway/templates/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+  labels:
+    app: {{ include "llm-gateway.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "llm-gateway.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "llm-gateway.name" . }}
+    spec:
+      containers:
+        - name: llm-gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8000
+          env:
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openai-api-key
+                  key: key

--- a/infra/helm/llm_gateway/templates/service.yaml
+++ b/infra/helm/llm_gateway/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+  selector:
+    app: {{ include "llm-gateway.name" . }}

--- a/infra/helm/llm_gateway/values.yaml
+++ b/infra/helm/llm_gateway/values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: betterbooks/llm-gateway
+  tag: latest
+service:
+  type: ClusterIP
+  port: 80

--- a/infra/helm/tts_service/Chart.yaml
+++ b/infra/helm/tts_service/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: tts-service
+version: 0.1.0
+appVersion: "1.0"

--- a/infra/helm/tts_service/templates/_helpers.tpl
+++ b/infra/helm/tts_service/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "tts-service.name" -}}
+tts-service
+{{- end -}}
+
+{{- define "tts-service.fullname" -}}
+{{ include "tts-service.name" . }}
+{{- end -}}

--- a/infra/helm/tts_service/templates/deployment.yaml
+++ b/infra/helm/tts_service/templates/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tts-service.fullname" . }}
+  labels:
+    app: {{ include "tts-service.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "tts-service.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "tts-service.name" . }}
+    spec:
+      containers:
+        - name: tts-service
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8000

--- a/infra/helm/tts_service/templates/service.yaml
+++ b/infra/helm/tts_service/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tts-service.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+  selector:
+    app: {{ include "tts-service.name" . }}

--- a/infra/helm/tts_service/values.yaml
+++ b/infra/helm/tts_service/values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: betterbooks/tts-service
+  tag: latest
+service:
+  type: ClusterIP
+  port: 80

--- a/infra/terraform/cluster/main.tf
+++ b/infra/terraform/cluster/main.tf
@@ -1,0 +1,29 @@
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  role_arn = var.cluster_role_arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+}
+
+resource "aws_eks_node_group" "default" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "default"
+  node_role_arn   = var.node_role_arn
+  subnet_ids      = var.subnet_ids
+
+  scaling_config {
+    desired_size = 2
+    max_size     = 2
+    min_size     = 1
+  }
+}
+
+output "endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_security_group" {
+  value = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+}

--- a/infra/terraform/cluster/variables.tf
+++ b/infra/terraform/cluster/variables.tf
@@ -1,0 +1,6 @@
+variable "cluster_name" {}
+variable "cluster_role_arn" {}
+variable "node_role_arn" {}
+variable "subnet_ids" {
+  type = list(string)
+}

--- a/infra/terraform/database/main.tf
+++ b/infra/terraform/database/main.tf
@@ -1,0 +1,20 @@
+resource "aws_db_instance" "this" {
+  identifier        = var.identifier
+  engine            = "postgres"
+  instance_class    = var.instance_class
+  allocated_storage = 20
+  db_subnet_group_name = aws_db_subnet_group.db.name
+  username          = var.username
+  password          = var.password
+  vpc_security_group_ids = var.vpc_security_group_ids
+  skip_final_snapshot = true
+}
+
+resource "aws_db_subnet_group" "db" {
+  name       = "${var.identifier}-subnets"
+  subnet_ids = var.subnet_ids
+}
+
+output "endpoint" {
+  value = aws_db_instance.this.endpoint
+}

--- a/infra/terraform/database/variables.tf
+++ b/infra/terraform/database/variables.tf
@@ -1,0 +1,12 @@
+variable "identifier" {}
+variable "username" {}
+variable "password" {
+  sensitive = true
+}
+variable "instance_class" {}
+variable "subnet_ids" {
+  type = list(string)
+}
+variable "vpc_security_group_ids" {
+  type = list(string)
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,1 +1,76 @@
-# Terraform configuration placeholder
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "cluster" {
+  source        = "./cluster"
+  cluster_name  = var.cluster_name
+  subnet_ids    = var.subnet_ids
+  cluster_role_arn = var.cluster_role_arn
+  node_role_arn    = var.node_role_arn
+}
+
+module "database" {
+  source                   = "./database"
+  identifier               = var.db_identifier
+  username                 = var.db_username
+  password                 = var.db_password
+  instance_class           = var.db_instance_class
+  subnet_ids               = var.subnet_ids
+  vpc_security_group_ids   = [module.cluster.cluster_security_group]
+}
+
+variable "aws_region" {
+  description = "AWS region"
+}
+
+variable "cluster_name" {
+  default = "betterbooks"
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "cluster_role_arn" {
+  description = "IAM role for the EKS cluster"
+}
+
+variable "node_role_arn" {
+  description = "IAM role for the worker nodes"
+}
+
+variable "db_identifier" {
+  default = "betterbooks-db"
+}
+
+variable "db_username" {
+  default = "betterbooks"
+}
+
+variable "db_password" {
+  description = "Database password"
+  sensitive   = true
+}
+
+variable "db_instance_class" {
+  default = "db.t3.micro"
+}
+
+output "cluster_endpoint" {
+  value = module.cluster.endpoint
+}
+
+output "db_endpoint" {
+  value = module.database.endpoint
+}


### PR DESCRIPTION
## Summary
- define EKS and RDS modules under `infra/terraform`
- add Helm charts for all four services
- expand `infra/README.md` with usage steps

## Testing
- `terraform version` *(fails: command not found)*
- `helm version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688313d622148333a67f23a8e3b961b4