### PR TITLE
Add helper scripts for setup and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ installed.
    ```
 
    The command builds the service images (if necessary) and starts the full
-   stack.
+   stack. You can also start everything using the helper script:
+
+   ```bash
+   ./scripts/run_app.sh
+   ```
 
 2. Once running you can access the services on the following ports:
 
@@ -46,5 +50,27 @@ installed.
 3. Stop the stack with `Ctrl+C` and remove containers with:
 
    ```bash
-   docker-compose down
-   ```
+ docker-compose down
+  ```
+
+## Running tests
+
+Python unit tests cover the FastAPI services. Install the required
+dependencies and run `pytest` from the repository root:
+
+```bash
+pip install -r services/api_gateway/requirements.txt \
+    -r services/context_service/requirements.txt \
+    -r services/llm_gateway/requirements.txt \
+    pgvector pytest
+pytest -q
+```
+
+Alternatively run:
+
+```bash
+./scripts/run_tests.sh
+```
+
+The tests mock heavy external dependencies so no database, OpenAI key or
+TTS model download is required.

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Python dependencies for all services and test utilities
+pip install -r services/api_gateway/requirements.txt \
+            -r services/context_service/requirements.txt \
+            -r services/llm_gateway/requirements.txt \
+            -r services/tts_service/requirements.txt \
+            pgvector pytest

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker-compose up --build

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install lightweight dependencies required for the tests
+pip install -r services/api_gateway/requirements.txt \
+            -r services/context_service/requirements.txt \
+            -r services/llm_gateway/requirements.txt \
+            pgvector pytest
+
+pytest -q

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,73 @@
+import importlib
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def test_api_gateway_health():
+    mod = importlib.import_module('services.api_gateway.main')
+    client = TestClient(mod.app)
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_llm_gateway_health():
+    patches = {
+        'openai.Completion.create': lambda **kwargs: MagicMock(choices=[MagicMock(text='hi')])
+    }
+    with patch('openai.Completion.create', lambda **kwargs: MagicMock(choices=[MagicMock(text='hi')])):
+        mod = importlib.import_module('services.llm_gateway.main')
+        client = TestClient(mod.app)
+        resp = client.get('/health')
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+def test_context_service_health():
+    class DummyCursor:
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            pass
+        def execute(self, *args, **kwargs):
+            pass
+        def fetchall(self):
+            return []
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+        def commit(self):
+            pass
+
+    with patch('psycopg.connect', lambda *a, **k: DummyConn()):
+        with patch('pgvector.psycopg.register_vector', lambda *a, **k: None):
+            mod = importlib.import_module('services.context_service.main')
+            client = TestClient(mod.app)
+            resp = client.get('/health')
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
+
+
+def test_tts_service_health():
+    class DummyTTS:
+        def __init__(self, *a, **k):
+            pass
+        def tts(self, text):
+            return b''
+        def save_wav(self, wav, path):
+            with open(path, 'wb') as f:
+                f.write(b'')
+
+    mock_module = MagicMock(TTS=DummyTTS)
+    with patch.dict('sys.modules', {'TTS.api': mock_module, 'TTS': MagicMock(api=mock_module)}):
+        mod = importlib.import_module('services.tts_service.main')
+        client = TestClient(mod.app)
+        resp = client.get('/health')
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add scripts to install dependencies, run the stack, and run tests
- document new scripts in README

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68831a1892dc83339ff7e1a05a3c95fd