### PR TITLE
Fix TTS build by installing g++

### DIFF
--- a/services/tts_service/Dockerfile
+++ b/services/tts_service/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ffmpeg \
         libsndfile1 \
         espeak-ng \
+        g++ \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./


### PR DESCRIPTION
## Summary
- ensure the TTS Docker image installs `g++`

## Testing
- `scripts/run_tests.sh`
- `docker build -t tts_service_test services/tts_service` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688321319fa08333b341e5c3e2efd382