### PR TITLE
Fix TTS Docker build by installing Rust toolchain

### DIFF
--- a/services/tts_service/Dockerfile
+++ b/services/tts_service/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsndfile1 \
         espeak-ng \
         g++ \
+        cargo \
+        rustc \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./


### PR DESCRIPTION
## Summary
- install `cargo` and `rustc` in the `tts_service` Dockerfile to satisfy `sudachipy` build requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68832436cdfc83339b73f44477f50fef