### PR TITLE
Create extension before registering vector type

### DIFF
--- a/services/context_service/main.py
+++ b/services/context_service/main.py
@@ -9,10 +9,17 @@ from pgvector.psycopg import register_vector
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost/postgres")
 
 conn = psycopg.connect(DATABASE_URL)
-register_vector(conn)
 
+# Ensure the pgvector extension is available before registering the vector type
 with conn.cursor() as cur:
     cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    conn.commit()
+
+# Register the vector type with psycopg
+register_vector(conn)
+
+# Create the embeddings table if it doesn't already exist
+with conn.cursor() as cur:
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS embeddings (


### PR DESCRIPTION
## Summary
- ensure pgvector extension is created prior to calling `register_vector`

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883afb004488333b97a5f7c1cd11afe