### PR TITLE
Remove merge artefacts from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,6 @@ Alternatively run:
 ./scripts/run_tests.sh
 ```
 
-=======
-    -r services/llm_gateway/requirements.txt
-pip install pgvector pytest
-pytest -q
-```
 
 The tests mock heavy external dependencies so no database, OpenAI key or
 TTS model download is required.


### PR DESCRIPTION
## Summary
- fix leftover merge markers in README's test instructions

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883afc746c88333891376e8498fbf23