### PR TITLE
Add simple web demo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,5 +47,12 @@ services:
     ports:
       - "8003:8000"
 
+  web_app:
+    build: ./web_app
+    depends_on:
+      - api_gateway
+    ports:
+      - "8080:80"
+
 volumes:
   postgres_data:

--- a/web_app/Dockerfile
+++ b/web_app/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html

--- a/web_app/README.md
+++ b/web_app/README.md
@@ -1,0 +1,7 @@
+# Web Demo
+
+Simple static site demonstrating the BetterBooks API.
+
+```
+# Build and run via docker-compose
+```

--- a/web_app/app.js
+++ b/web_app/app.js
@@ -1,0 +1,45 @@
+const apiBase = 'http://localhost:8000';
+
+const audioInput = document.getElementById('audioFile');
+const audioPlayer = document.getElementById('audioPlayer');
+
+audioInput.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (file) {
+    audioPlayer.src = URL.createObjectURL(file);
+  }
+});
+
+document.getElementById('sendText').addEventListener('click', async () => {
+  const prompt = document.getElementById('prompt').value;
+  const respDiv = document.getElementById('response');
+  respDiv.textContent = 'Loading...';
+  try {
+    const res = await fetch(`${apiBase}/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    });
+    const data = await res.json();
+    respDiv.textContent = data.text || JSON.stringify(data);
+  } catch (err) {
+    respDiv.textContent = 'Error: ' + err;
+  }
+});
+
+const voiceBtn = document.getElementById('startVoice');
+if (voiceBtn) {
+  voiceBtn.addEventListener('click', () => {
+    if (!('webkitSpeechRecognition' in window)) {
+      alert('Speech recognition not supported in this browser.');
+      return;
+    }
+    const recognition = new webkitSpeechRecognition();
+    recognition.lang = 'en-US';
+    recognition.onresult = function(event) {
+      const transcript = event.results[0][0].transcript;
+      document.getElementById('prompt').value = transcript;
+    };
+    recognition.start();
+  });
+}

--- a/web_app/index.html
+++ b/web_app/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>BetterBooks Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    textarea { width: 300px; height: 80px; display:block; margin-top:1rem; }
+    #response { margin-top: 1rem; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>BetterBooks Demo</h1>
+  <input type="file" id="audioFile" accept="audio/*" />
+  <br/>
+  <audio id="audioPlayer" controls></audio>
+  <textarea id="prompt" placeholder="Ask a question"></textarea>
+  <button id="sendText">Send</button>
+  <button id="startVoice">Speak</button>
+  <div id="response"></div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a `web_app` directory with a minimal HTML/JS demo
- serve the demo using nginx via a new Dockerfile
- expose the new service from `docker-compose.yml`
- JS provides audio file playback and calls the API Gateway

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885a3a4baf0833382f71207bf5b297f