### PR TITLE
Improve run script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ installed.
    - **Context Service:** <http://localhost:8001>
    - **LLM Gateway:** <http://localhost:8002>
    - **TTS Service:** <http://localhost:8003>
+   - **Web Demo:** <http://localhost:8080>
+
+  Open <http://localhost:8080> in your browser to view the simple demo page.
 
   Postgres runs from the `pgvector/pgvector:pg15` image so the `pgvector`
   extension is available. It is exposed on port `5432` with the default

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -4,5 +4,11 @@
 # Exit immediately on errors and propagate errors through pipes.
 set -euo pipefail
 
+# Determine the repository root and switch to it so docker-compose
+# can locate the docker-compose.yml file even if the script was
+# executed from another directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
 # Build images if necessary and then launch the services in the foreground.
 docker-compose up --build

--- a/web_app/README.md
+++ b/web_app/README.md
@@ -2,6 +2,6 @@
 
 Simple static site demonstrating the BetterBooks API.
 
-```
-# Build and run via docker-compose
-```
+This container is started automatically when running `docker-compose` from the
+repository root (or via `./scripts/run_app.sh`). Once the stack is running,
+navigate to <http://localhost:8080> in your browser to view the demo page.


### PR DESCRIPTION
## Summary
- make `run_app.sh` work regardless of current directory
- document how to access the web app
- expand web demo instructions

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885b992c044833380aae4af9796b8ec