### PR TITLE
Fix CORS and document API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ This repository includes a `docker-compose.yml` file for spinning up all
 services along with a Postgres database. Docker and Docker Compose must be
 installed.
 
-1. From the repository root run:
+1. Export your OpenAI API key so it can be passed into the language model
+   service and then start the stack:
 
    ```bash
+   export OPENAI_API_KEY=your-key
    docker-compose up --build
    ```
+
+   You can confirm the key is available inside the container with
+   `docker-compose exec llm_gateway env | grep OPENAI_API_KEY`.
 
    The command builds the service images (if necessary) and starts the full
    stack. You can also start everything using the helper script:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
 
   llm_gateway:
     build: ./services/llm_gateway
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
     ports:
       - "8002:8000"
 

--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -9,6 +9,7 @@ import os
 
 import httpx
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 # Base URLs for the other services. These can be overridden via environment
@@ -19,6 +20,15 @@ TTS_URL = os.getenv("TTS_SERVICE_URL", "http://tts_service:8000")
 
 # Main FastAPI application used by the unit tests and docker-compose setup
 app = FastAPI()
+
+# Allow requests from the web demo running on a different port. Without CORS
+# the browser would block calls from the 8080 UI to the gateway on 8000.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/health")
 def health() -> dict:


### PR DESCRIPTION
## Summary
- enable CORS for API Gateway so the web demo can call it
- pass `OPENAI_API_KEY` through docker-compose
- document how to supply the OpenAI API key and verify it

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885c8e7a9208333a4281e8ad2e2ebcb