### PR TITLE
Update LLM gateway for OpenAI v1

### DIFF
--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -2,12 +2,12 @@
 
 import os
 
-import openai
+from openai import OpenAI
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-# Configure the OpenAI SDK using the API key provided in the environment.
-openai.api_key = os.getenv("OPENAI_API_KEY")
+# Create an OpenAI client using the API key provided in the environment.
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 # FastAPI application instance
 app = FastAPI()
@@ -29,7 +29,7 @@ class CompletionRequest(BaseModel):
 def complete(req: CompletionRequest) -> dict:
     """Call OpenAI to generate a text completion."""
 
-    resp = openai.Completion.create(
+    resp = client.completions.create(
         model="text-davinci-003",
         prompt=req.prompt,
         max_tokens=req.max_tokens,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -25,8 +25,8 @@ def test_llm_gateway_health():
     """Health check for the LLM Gateway with OpenAI mocked out."""
 
     with patch(
-        "openai.Completion.create",
-        lambda **kwargs: MagicMock(choices=[MagicMock(text="hi")]),
+        "openai.resources.completions.Completions.create",
+        lambda *a, **kwargs: MagicMock(choices=[MagicMock(text="hi")]),
     ):
         mod = importlib.import_module("services.llm_gateway.main")
         client = TestClient(mod.app)


### PR DESCRIPTION
## Summary
- use `openai.OpenAI` client in LLM gateway
- adjust tests to patch new method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d7f34e5c833387985013c0c15a21