### PR TITLE
Fix LLM gateway model usage

### DIFF
--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -53,6 +53,7 @@ def complete(prompt: Prompt) -> dict:
     """Proxy text completion requests to the LLM Gateway."""
 
     resp = httpx.post(f"{LLM_URL}/complete", json=prompt.dict())
+    resp.raise_for_status()
     return resp.json()
 
 

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -6,6 +6,8 @@ from openai import OpenAI
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from .prompt_modifier import modify_prompt
+
 # Create an OpenAI client using the API key provided in the environment.  When
 # running unit tests the key may not be set so we fall back to a dummy value to
 # avoid initialization errors.
@@ -31,10 +33,11 @@ class CompletionRequest(BaseModel):
 def complete(req: CompletionRequest) -> dict:
     """Call OpenAI to generate a text completion."""
 
-    resp = client.completions.create(
-        model="gpt-3.5-turbo-instruct",
-        prompt=req.prompt,
+    prompt = modify_prompt(req.prompt)
+    resp = client.chat.completions.create(
+        model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+        messages=[{"role": "user", "content": prompt}],
         max_tokens=req.max_tokens,
     )
-    return {"text": resp.choices[0].text.strip()}
+    return {"text": resp.choices[0].message.content.strip()}
 

--- a/services/llm_gateway/prompt_modifier.py
+++ b/services/llm_gateway/prompt_modifier.py
@@ -1,0 +1,40 @@
+"""Utility functions for customizing prompts before sending them to the LLM."""
+
+from typing import Any, Dict
+
+
+def modify_prompt(prompt: str, options: Dict[str, Any] | None = None) -> str:
+    """Return a prompt extended with optional style instructions.
+
+    Parameters
+    ----------
+    prompt:
+        The original user prompt.
+    options:
+        Optional dictionary allowing callers to influence the tone, length,
+        persona, etc.  Unknown keys are ignored so additional values can be
+        added in the future without breaking callers.
+    """
+
+    if not options:
+        options = {}
+
+    extras: list[str] = []
+
+    tone = options.get("tone")
+    if tone:
+        extras.append(f"Use a {tone} tone.")
+
+    length = options.get("length")
+    if length:
+        extras.append(f"Keep the response {length}.")
+
+    persona = options.get("persona")
+    if persona:
+        extras.append(f"Respond as the {persona}.")
+
+    if not extras:
+        return prompt
+
+    preprompt = " ".join(extras)
+    return f"{preprompt}\n\n{prompt}"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -25,8 +25,10 @@ def test_llm_gateway_health():
     """Health check for the LLM Gateway with OpenAI mocked out."""
 
     with patch(
-        "openai.resources.completions.Completions.create",
-        lambda *a, **kwargs: MagicMock(choices=[MagicMock(text="hi")]),
+        "openai.resources.chat.completions.Completions.create",
+        lambda *a, **kwargs: MagicMock(
+            choices=[MagicMock(message=MagicMock(content="hi"))]
+        ),
     ):
         mod = importlib.import_module("services.llm_gateway.main")
         client = TestClient(mod.app)


### PR DESCRIPTION
## Summary
- switch LLM gateway to chat completions and support configurable model
- add dynamic `prompt_modifier` helper for tweaking prompts
- check for errors when proxying from API gateway
- update unit tests for new chat completion mock

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6885e40640a88333a4ae3b11a7ee4899