### PR TITLE
Fix LLM gateway tests without OpenAI

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,6 +6,7 @@ import sys
 from unittest.mock import patch, MagicMock
 
 from fastapi.testclient import TestClient
+import types
 
 # Ensure the services package can be imported when running tests directly
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -23,18 +24,28 @@ def test_api_gateway_health():
 
 def test_llm_gateway_health():
     """Health check for the LLM Gateway with OpenAI mocked out."""
+    dummy_openai = types.ModuleType("openai")
+    dummy_openai.OpenAI = MagicMock
+    dummy_openai.resources = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(
+                Completions=types.SimpleNamespace(create=lambda *a, **k: None)
+            )
+        )
+    )
 
-    with patch(
-        "openai.resources.chat.completions.Completions.create",
-        lambda *a, **kwargs: MagicMock(
-            choices=[MagicMock(message=MagicMock(content="hi"))]
-        ),
-    ):
-        mod = importlib.import_module("services.llm_gateway.main")
-        client = TestClient(mod.app)
-        resp = client.get("/health")
-        assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
+    with patch.dict("sys.modules", {"openai": dummy_openai}):
+        with patch(
+            "openai.resources.chat.completions.Completions.create",
+            lambda *a, **kwargs: MagicMock(
+                choices=[MagicMock(message=MagicMock(content="hi"))]
+            ),
+        ):
+            mod = importlib.import_module("services.llm_gateway.main")
+            client = TestClient(mod.app)
+            resp = client.get("/health")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
 
 
 def test_context_service_health():


### PR DESCRIPTION
## Summary
- handle missing OpenAI dependency in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6885e6c783d883339bf6b1f045bb88c4