### PR TITLE
Fix LLM gateway dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ installed.
    ./scripts/run_app.sh
    ```
 
+   The LLM Gateway uses version 1.x of the `openai` Python package. If the
+   image build installs an older release the gateway will fail to start with
+   an import error. Ensure the build has network access so `openai>=1.0` can be
+   installed.
+
 2. Once running you can access the services on the following ports:
 
    - **API Gateway:** <http://localhost:8000>

--- a/services/llm_gateway/requirements.txt
+++ b/services/llm_gateway/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
 uvicorn[standard]
-openai
+openai>=1.0


### PR DESCRIPTION
## Summary
- pin `openai` dependency to 1.x so the gateway starts correctly
- document `openai>=1.0` requirement in the README

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6885e97c29a483339cb816a7fd4e10d4