### PR TITLE
Improve LLM error handling

### DIFF
--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -8,7 +8,7 @@ lightweight HTTP request to another service and returns the response verbatim.
 import os
 
 import httpx
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -53,7 +53,14 @@ def complete(prompt: Prompt) -> dict:
     """Proxy text completion requests to the LLM Gateway."""
 
     resp = httpx.post(f"{LLM_URL}/complete", json=prompt.dict())
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError:
+        # Bubble up the error from the LLM Gateway so the client receives a
+        # meaningful status code instead of a generic 500 from this service.
+        detail = resp.json().get("detail", resp.text)
+        raise HTTPException(status_code=resp.status_code, detail=detail)
+
     return resp.json()
 
 

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -2,8 +2,13 @@
 
 import os
 
-from openai import OpenAI
-from fastapi import FastAPI
+try:  # pragma: no cover - library may not be installed during tests
+    from openai import OpenAI, OpenAIError, RateLimitError
+except Exception:  # pragma: no cover - openai is replaced with a stub in tests
+    from openai import OpenAI  # type: ignore
+    OpenAIError = Exception  # type: ignore
+    RateLimitError = Exception  # type: ignore
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 # Import the prompt modification helper. When the service runs inside Docker the
@@ -41,10 +46,22 @@ def complete(req: CompletionRequest) -> dict:
     """Call OpenAI to generate a text completion."""
 
     prompt = modify_prompt(req.prompt)
-    resp = client.chat.completions.create(
-        model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
-        messages=[{"role": "user", "content": prompt}],
-        max_tokens=req.max_tokens,
-    )
+    try:
+        resp = client.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=req.max_tokens,
+        )
+    except RateLimitError as exc:  # pragma: no cover - requires actual API call
+        # If the OpenAI API rejects the request due to usage limits or invalid
+        # credentials return a 429 to indicate the upstream service is
+        # unavailable. This normally happens in development when the API key is
+        # missing or exhausted.
+        raise HTTPException(status_code=429, detail=str(exc))
+    except OpenAIError as exc:  # pragma: no cover - requires actual API call
+        # Catch all other OpenAI related errors and return a generic 502 so the
+        # caller knows the request failed.
+        raise HTTPException(status_code=502, detail=str(exc))
+
     return {"text": resp.choices[0].message.content.strip()}
 


### PR DESCRIPTION
## Summary
- handle OpenAI errors in llm_gateway
- propagate error responses in api_gateway

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885eab7cdc08333a97651d576a0e4ca