### PR TITLE
Switch LLM Gateway to Gemini API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ This repository includes a `docker-compose.yml` file for spinning up all
 services along with a Postgres database. Docker and Docker Compose must be
 installed.
 
-1. Export your OpenAI API key so it can be passed into the language model
+1. Export your Gemini API key so it can be passed into the language model
    service and then start the stack:
 
    ```bash
-   export OPENAI_API_KEY=your-key
+   export GEMINI_API_KEY=your-key
    docker-compose up --build
    ```
 
    You can confirm the key is available inside the container with
-   `docker-compose exec llm_gateway env | grep OPENAI_API_KEY`.
+   `docker-compose exec llm_gateway env | grep GEMINI_API_KEY`.
 
    The command builds the service images (if necessary) and starts the full
    stack. You can also start everything using the helper script:
@@ -41,10 +41,8 @@ installed.
    ./scripts/run_app.sh
    ```
 
-   The LLM Gateway uses version 1.x of the `openai` Python package. If the
-   image build installs an older release the gateway will fail to start with
-   an import error. Ensure the build has network access so `openai>=1.0` can be
-   installed.
+   The LLM Gateway relies on the `google-generativeai` package. Ensure the
+   image build has network access so the latest version can be installed.
 
 2. Once running you can access the services on the following ports:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
   llm_gateway:
     build: ./services/llm_gateway
     environment:
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
     ports:
       - "8002:8000"
 

--- a/docs/CUSTOMIZATION_GUIDE.md
+++ b/docs/CUSTOMIZATION_GUIDE.md
@@ -8,7 +8,7 @@ The Flutter application lives under `mobile_app/`. Edit `lib/main.dart` or add n
 
 ## 2. Experiment with different language models
 
-The service responsible for interacting with the language model is `services/llm_gateway`. Modify `main.py` or replace the OpenAI client with a different provider to try other models. The API Gateway forwards `/complete` requests directly to this service.
+The service responsible for interacting with the language model is `services/llm_gateway`. Modify `main.py` or adjust `config.json` to experiment with different models. The API Gateway forwards `/complete` requests directly to this service.
 
 ## 3. Change the preprompt
 

--- a/infra/helm/llm_gateway/templates/deployment.yaml
+++ b/infra/helm/llm_gateway/templates/deployment.yaml
@@ -20,8 +20,8 @@ spec:
           ports:
             - containerPort: 8000
           env:
-            - name: OPENAI_API_KEY
+            - name: GEMINI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: openai-api-key
+                  name: gemini-api-key
                   key: key

--- a/services/llm_gateway/README.md
+++ b/services/llm_gateway/README.md
@@ -1,14 +1,17 @@
 # LLM Gateway
 
 Provides a REST endpoint that proxies requests to the configured language model
-(OpenAI by default).
+(Gemini by default).
 
 ### Running
 
 ```
-export OPENAI_API_KEY=your-key
+export GEMINI_API_KEY=your-key
 uvicorn main:app --reload
 ```
+
+Configuration options such as the model name and generation settings can be
+adjusted in `config.json`.
 
 ### Example
 

--- a/services/llm_gateway/config.json
+++ b/services/llm_gateway/config.json
@@ -1,0 +1,7 @@
+{
+  "api_key": "",
+  "model": "gemini-pro",
+  "generation_config": {
+    "temperature": 0.7
+  }
+}

--- a/services/llm_gateway/config.py
+++ b/services/llm_gateway/config.py
@@ -1,0 +1,27 @@
+"""Configuration loader for the Gemini LLM Gateway."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+
+DEFAULT_PATH = Path(__file__).with_name("config.json")
+
+
+def load_config(path: str | Path | None = None) -> Dict[str, Any]:
+    """Load configuration from a JSON file and environment variables."""
+    cfg_path = Path(path or os.getenv("GEMINI_CONFIG", DEFAULT_PATH))
+    data: Dict[str, Any] = {}
+    if cfg_path.exists():
+        with open(cfg_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    data.setdefault("model", "gemini-pro")
+    data.setdefault("generation_config", {"temperature": 0.7})
+    env_key = os.getenv("GEMINI_API_KEY")
+    if env_key:
+        data["api_key"] = env_key
+    data.setdefault("api_key", "test-key")
+    return data

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -1,13 +1,14 @@
-"""Tiny wrapper around the OpenAI API used for text generation."""
+"""Tiny wrapper around the Gemini API used for text generation."""
 
 import os
+import types
 
 try:  # pragma: no cover - library may not be installed during tests
-    from openai import OpenAI, OpenAIError, RateLimitError
-except Exception:  # pragma: no cover - openai is replaced with a stub in tests
-    from openai import OpenAI  # type: ignore
-    OpenAIError = Exception  # type: ignore
-    RateLimitError = Exception  # type: ignore
+    import google.generativeai as genai
+    from google.generativeai.types import GenerationConfig
+except Exception:  # pragma: no cover - the library may be stubbed in tests
+    genai = types.SimpleNamespace(configure=lambda *a, **k: None, GenerativeModel=lambda *a, **k: None)  # type: ignore
+    GenerationConfig = dict  # type: ignore
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
@@ -20,10 +21,13 @@ try:  # pragma: no cover - import tested implicitly
 except ImportError:  # pragma: no cover - running as a script
     from prompt_modifier import modify_prompt
 
-# Create an OpenAI client using the API key provided in the environment.  When
-# running unit tests the key may not be set so we fall back to a dummy value to
-# avoid initialization errors.
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", "sk-test"))
+from .config import load_config
+
+cfg = load_config()
+
+genai.configure(api_key=cfg["api_key"])
+model = genai.GenerativeModel(cfg["model"])
+gen_config_defaults = cfg.get("generation_config", {})
 
 # FastAPI application instance
 app = FastAPI()
@@ -43,25 +47,22 @@ class CompletionRequest(BaseModel):
 
 @app.post("/complete")
 def complete(req: CompletionRequest) -> dict:
-    """Call OpenAI to generate a text completion."""
+    """Call Gemini to generate a text completion."""
 
     prompt = modify_prompt(req.prompt)
     try:
-        resp = client.chat.completions.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=req.max_tokens,
+        config = GenerationConfig(
+            **{
+                **gen_config_defaults,
+                "max_output_tokens": req.max_tokens,
+            }
         )
-    except RateLimitError as exc:  # pragma: no cover - requires actual API call
-        # If the OpenAI API rejects the request due to usage limits or invalid
-        # credentials return a 429 to indicate the upstream service is
-        # unavailable. This normally happens in development when the API key is
-        # missing or exhausted.
-        raise HTTPException(status_code=429, detail=str(exc))
-    except OpenAIError as exc:  # pragma: no cover - requires actual API call
-        # Catch all other OpenAI related errors and return a generic 502 so the
-        # caller knows the request failed.
+        resp = model.generate_content(
+            prompt,
+            generation_config=config,
+        )
+    except Exception as exc:  # pragma: no cover - requires actual API call
         raise HTTPException(status_code=502, detail=str(exc))
 
-    return {"text": resp.choices[0].message.content.strip()}
+    return {"text": resp.text.strip()}
 

--- a/services/llm_gateway/requirements.txt
+++ b/services/llm_gateway/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
 uvicorn[standard]
-openai>=1.0
+google-generativeai

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -23,29 +23,31 @@ def test_api_gateway_health():
 
 
 def test_llm_gateway_health():
-    """Health check for the LLM Gateway with OpenAI mocked out."""
-    dummy_openai = types.ModuleType("openai")
-    dummy_openai.OpenAI = MagicMock
-    dummy_openai.resources = types.SimpleNamespace(
-        chat=types.SimpleNamespace(
-            completions=types.SimpleNamespace(
-                Completions=types.SimpleNamespace(create=lambda *a, **k: None)
-            )
-        )
-    )
+    """Health check for the LLM Gateway with Gemini mocked out."""
 
-    with patch.dict("sys.modules", {"openai": dummy_openai}):
-        with patch(
-            "openai.resources.chat.completions.Completions.create",
-            lambda *a, **kwargs: MagicMock(
-                choices=[MagicMock(message=MagicMock(content="hi"))]
-            ),
-        ):
-            mod = importlib.import_module("services.llm_gateway.main")
-            client = TestClient(mod.app)
-            resp = client.get("/health")
-            assert resp.status_code == 200
-            assert resp.json() == {"status": "ok"}
+    dummy_genai = types.ModuleType("google.generativeai")
+    dummy_types = types.ModuleType("google.generativeai.types")
+    dummy_genai.configure = lambda *a, **k: None
+
+    class DummyModel:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate_content(self, *a, **k):
+            return types.SimpleNamespace(text="hi")
+
+    dummy_genai.GenerativeModel = DummyModel
+    dummy_types.GenerationConfig = MagicMock(return_value={})
+
+    with patch.dict(
+        "sys.modules",
+        {"google.generativeai": dummy_genai, "google.generativeai.types": dummy_types},
+    ):
+        mod = importlib.import_module("services.llm_gateway.main")
+        client = TestClient(mod.app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
 
 
 def test_context_service_health():


### PR DESCRIPTION
## Summary
- replace OpenAI usage with Google Gemini
- add configurable settings in `config.json`
- update docs and deployment files for `GEMINI_API_KEY`
- adjust unit tests for Gemini

## Testing
- `pip install -r services/api_gateway/requirements.txt -r services/context_service/requirements.txt -r services/llm_gateway/requirements.txt pgvector pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688668f1da64833387faef052e2106a5