### PR TITLE
Fix LLM gateway startup issues

### DIFF
--- a/services/llm_gateway/README.md
+++ b/services/llm_gateway/README.md
@@ -1,7 +1,7 @@
 # LLM Gateway
 
-Provides a REST endpoint that proxies requests to the configured language model
-(Gemini by default).
+Provides a REST endpoint that proxies requests to the configured Gemini
+language model. By default it uses the `gemini-2.0-flash` model.
 
 ### Running
 

--- a/services/llm_gateway/config.json
+++ b/services/llm_gateway/config.json
@@ -1,6 +1,6 @@
 {
   "api_key": "",
-  "model": "gemini-pro",
+  "model": "gemini-2.0-flash",
   "generation_config": {
     "temperature": 0.7
   }

--- a/services/llm_gateway/config.py
+++ b/services/llm_gateway/config.py
@@ -18,7 +18,7 @@ def load_config(path: str | Path | None = None) -> Dict[str, Any]:
     if cfg_path.exists():
         with open(cfg_path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
-    data.setdefault("model", "gemini-pro")
+    data.setdefault("model", "gemini-2.0-flash")
     data.setdefault("generation_config", {"temperature": 0.7})
     env_key = os.getenv("GEMINI_API_KEY")
     if env_key:

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -13,15 +13,18 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 # Import the prompt modification helper. When the service runs inside Docker the
-# `main.py` file is executed directly (``uvicorn main:app``), so the relative
-# import fails. Fall back to an absolute import in that scenario to keep local
-# tests working.
+# ``main.py`` file is executed directly (``uvicorn main:app``). In that case the
+# module is executed as a script and relative imports fail. Fall back to
+# absolute imports so local tests keep working.
 try:  # pragma: no cover - import tested implicitly
     from .prompt_modifier import modify_prompt
 except ImportError:  # pragma: no cover - running as a script
     from prompt_modifier import modify_prompt
 
-from .config import load_config
+try:  # pragma: no cover - import tested implicitly
+    from .config import load_config
+except ImportError:  # pragma: no cover - running as a script
+    from config import load_config
 
 cfg = load_config()
 


### PR DESCRIPTION
## Summary
- handle running `main.py` as a script
- default to the `gemini-2.0-flash` model
- update documentation for new model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866f13b7cc8333bb3773da8cb3e4cd