### PR TITLE
Add root configuration for LLM gateway

### DIFF
--- a/docs/CUSTOMIZATION_GUIDE.md
+++ b/docs/CUSTOMIZATION_GUIDE.md
@@ -8,11 +8,11 @@ The Flutter application lives under `mobile_app/`. Edit `lib/main.dart` or add n
 
 ## 2. Experiment with different language models
 
-The service responsible for interacting with the language model is `services/llm_gateway`. Modify `main.py` or adjust `config.json` to experiment with different models. The API Gateway forwards `/complete` requests directly to this service.
+The service responsible for interacting with the language model is `services/llm_gateway`. Modify `main.py` or adjust `llm_config.json` in the repository root to experiment with different models or pre‑prompt settings. The API Gateway forwards `/complete` requests directly to this service.
 
 ## 3. Change the preprompt
 
-A preprompt can be injected before the user prompt inside `services/llm_gateway/main.py`. Insert custom logic in the `complete` endpoint to prepend your preprompt to `req.prompt` before sending the request to the LLM.
+You can set a default preprompt in `llm_config.json` using the `base_preprompt` field. This text is prepended to every user prompt. Alternatively, modify `services/llm_gateway/main.py` to implement more advanced logic before the request is sent to the LLM.
 
 ## 4. Change how the story is read to the user
 

--- a/llm_config.json
+++ b/llm_config.json
@@ -1,0 +1,13 @@
+{
+  "api_key": "",
+  "model": "gemini-2.0-flash",
+  "generation_config": {
+    "temperature": 0.7
+  },
+  "prompt_options": {
+    "tone": "helpful",
+    "length": "concise",
+    "persona": "friendly assistant"
+  },
+  "base_preprompt": "You are speaking to an audiobook enthusiast using the BetterBooks platform."
+}

--- a/services/llm_gateway/README.md
+++ b/services/llm_gateway/README.md
@@ -10,8 +10,8 @@ export GEMINI_API_KEY=your-key
 uvicorn main:app --reload
 ```
 
-Configuration options such as the model name and generation settings can be
-adjusted in `config.json`.
+Configuration options such as the model name, generation settings and default
+preprompt can be adjusted in `llm_config.json` at the repository root.
 
 ### Example
 

--- a/services/llm_gateway/config.py
+++ b/services/llm_gateway/config.py
@@ -8,18 +8,30 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-DEFAULT_PATH = Path(__file__).with_name("config.json")
+# Look for a global configuration file at the repository root.  Fall back to the
+# legacy local file if it doesn't exist.
+DEFAULT_ROOT_PATH = Path(__file__).resolve().parents[2] / "llm_config.json"
+DEFAULT_LOCAL_PATH = Path(__file__).with_name("config.json")
 
 
 def load_config(path: str | Path | None = None) -> Dict[str, Any]:
     """Load configuration from a JSON file and environment variables."""
-    cfg_path = Path(path or os.getenv("GEMINI_CONFIG", DEFAULT_PATH))
+    env_path = os.getenv("GEMINI_CONFIG")
+    if path:
+        cfg_path = Path(path)
+    elif env_path:
+        cfg_path = Path(env_path)
+    else:
+        cfg_path = DEFAULT_ROOT_PATH if DEFAULT_ROOT_PATH.exists() else DEFAULT_LOCAL_PATH
+
     data: Dict[str, Any] = {}
     if cfg_path.exists():
         with open(cfg_path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
     data.setdefault("model", "gemini-2.0-flash")
     data.setdefault("generation_config", {"temperature": 0.7})
+    data.setdefault("prompt_options", {})
+    data.setdefault("base_preprompt", "")
     env_key = os.getenv("GEMINI_API_KEY")
     if env_key:
         data["api_key"] = env_key

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -27,6 +27,8 @@ except ImportError:  # pragma: no cover - running as a script
     from config import load_config
 
 cfg = load_config()
+prompt_options = cfg.get("prompt_options", {})
+base_preprompt = cfg.get("base_preprompt", "")
 
 genai.configure(api_key=cfg["api_key"])
 model = genai.GenerativeModel(cfg["model"])
@@ -52,7 +54,9 @@ class CompletionRequest(BaseModel):
 def complete(req: CompletionRequest) -> dict:
     """Call Gemini to generate a text completion."""
 
-    prompt = modify_prompt(req.prompt)
+    prompt = modify_prompt(req.prompt, prompt_options)
+    if base_preprompt:
+        prompt = f"{base_preprompt}\n\n{prompt}"
     try:
         config = GenerationConfig(
             **{


### PR DESCRIPTION
## Summary
- load LLM gateway configuration from new `llm_config.json` at repo root
- add preprompt options so prompts can be customized via config file
- document new configuration path in docs and service README
- provide sample `llm_config.json` for easy editing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688672e17f648333a48ea4ab7163d7d1