### PR TITLE
Add persona selection via llm_configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ mobile application and all backend microservices.
   - `tts_service/` – Generates audio snippets.
 - `proto/` – gRPC/Protobuf definitions.
 - `infra/` – Terraform and Helm deployment configurations.
+- `llm_configs/` – Example personas and model settings selectable in the demo UI.
 
 Each service is a small FastAPI application packaged with a Dockerfile and
 currently exposes only a simple `/health` endpoint.
@@ -50,9 +51,9 @@ installed.
    - **Context Service:** <http://localhost:8001>
    - **LLM Gateway:** <http://localhost:8002>
    - **TTS Service:** <http://localhost:8003>
-   - **Web Demo:** <http://localhost:8080>
+  - **Web Demo:** <http://localhost:8080>
 
-  Open <http://localhost:8080> in your browser to view the simple demo page.
+  Open <http://localhost:8080> in your browser to view the simple demo page. A drop-down lets you choose any configuration from `llm_configs/` before sending a prompt.
 
   Postgres runs from the `pgvector/pgvector:pg15` image so the `pgvector`
   extension is available. It is exposed on port `5432` with the default

--- a/docs/CUSTOMIZATION_GUIDE.md
+++ b/docs/CUSTOMIZATION_GUIDE.md
@@ -8,11 +8,11 @@ The Flutter application lives under `mobile_app/`. Edit `lib/main.dart` or add n
 
 ## 2. Experiment with different language models
 
-The service responsible for interacting with the language model is `services/llm_gateway`. Modify `main.py` or adjust `llm_config.json` in the repository root to experiment with different models or pre‑prompt settings. The API Gateway forwards `/complete` requests directly to this service.
+The service responsible for interacting with the language model is `services/llm_gateway`. Modify `main.py`, update `llm_config.json`, or create additional files under the `llm_configs/` directory to experiment with different models or pre‑prompt settings. The API Gateway forwards `/complete` requests directly to this service and the web UI lets you choose any config from that folder.
 
 ## 3. Change the preprompt
 
-You can set a default preprompt in `llm_config.json` using the `base_preprompt` field. This text is prepended to every user prompt. Alternatively, modify `services/llm_gateway/main.py` to implement more advanced logic before the request is sent to the LLM.
+You can set a default preprompt in `llm_config.json` using the `base_preprompt` field or provide specialized configs under `llm_configs/`. Each config file can specify its own `base_preprompt` that will be used when selected in the UI. Alternatively, modify `services/llm_gateway/main.py` to implement more advanced logic before the request is sent to the LLM.
 
 ## 4. Change how the story is read to the user
 

--- a/services/api_gateway/main.py
+++ b/services/api_gateway/main.py
@@ -40,6 +40,7 @@ class Prompt(BaseModel):
     """Request body for the `/complete` endpoint."""
 
     prompt: str
+    config: str | None = None
 
 
 class Text(BaseModel):
@@ -52,7 +53,7 @@ class Text(BaseModel):
 def complete(prompt: Prompt) -> dict:
     """Proxy text completion requests to the LLM Gateway."""
 
-    resp = httpx.post(f"{LLM_URL}/complete", json=prompt.dict())
+    resp = httpx.post(f"{LLM_URL}/complete", json=prompt.dict(exclude_none=True))
     try:
         resp.raise_for_status()
     except httpx.HTTPStatusError:
@@ -69,6 +70,14 @@ def tts(text: Text) -> dict:
     """Proxy text-to-speech synthesis requests to the TTS Service."""
 
     resp = httpx.post(f"{TTS_URL}/synthesize", json=text.dict())
+    return resp.json()
+
+
+@app.get("/configs")
+def list_configs() -> dict:
+    """Return available LLM configuration names."""
+
+    resp = httpx.get(f"{LLM_URL}/configs")
     return resp.json()
 
 

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -9,6 +9,7 @@ try:  # pragma: no cover - library may not be installed during tests
 except Exception:  # pragma: no cover - the library may be stubbed in tests
     genai = types.SimpleNamespace(configure=lambda *a, **k: None, GenerativeModel=lambda *a, **k: None)  # type: ignore
     GenerationConfig = dict  # type: ignore
+from pathlib import Path
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
@@ -30,6 +31,9 @@ cfg = load_config()
 prompt_options = cfg.get("prompt_options", {})
 base_preprompt = cfg.get("base_preprompt", "")
 
+# Directory containing additional LLM configuration JSON files
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "llm_configs"
+
 genai.configure(api_key=cfg["api_key"])
 model = genai.GenerativeModel(cfg["model"])
 gen_config_defaults = cfg.get("generation_config", {})
@@ -48,23 +52,39 @@ class CompletionRequest(BaseModel):
 
     prompt: str
     max_tokens: int = 50
+    config: str | None = None
 
 
 @app.post("/complete")
 def complete(req: CompletionRequest) -> dict:
     """Call Gemini to generate a text completion."""
 
-    prompt = modify_prompt(req.prompt, prompt_options)
-    if base_preprompt:
-        prompt = f"{base_preprompt}\n\n{prompt}"
+    # Load configuration based on the optional `config` parameter. Defaults
+    # to the main configuration loaded at startup.
+    cfg_local = cfg
+    if req.config:
+        cfg_path = CONFIG_DIR / f"{req.config}.json"
+        if not cfg_path.exists():
+            raise HTTPException(status_code=400, detail="Unknown config")
+        cfg_local = load_config(cfg_path)
+
+    local_prompt_options = cfg_local.get("prompt_options", {})
+    local_base_preprompt = cfg_local.get("base_preprompt", "")
+
+    prompt = modify_prompt(req.prompt, local_prompt_options)
+    if local_base_preprompt:
+        prompt = f"{local_base_preprompt}\n\n{prompt}"
     try:
+        genai.configure(api_key=cfg_local["api_key"])
+        model_local = genai.GenerativeModel(cfg_local["model"])
+        gen_config_defaults_local = cfg_local.get("generation_config", {})
         config = GenerationConfig(
             **{
-                **gen_config_defaults,
+                **gen_config_defaults_local,
                 "max_output_tokens": req.max_tokens,
             }
         )
-        resp = model.generate_content(
+        resp = model_local.generate_content(
             prompt,
             generation_config=config,
         )
@@ -72,4 +92,14 @@ def complete(req: CompletionRequest) -> dict:
         raise HTTPException(status_code=502, detail=str(exc))
 
     return {"text": resp.text.strip()}
+
+
+@app.get("/configs")
+def list_configs() -> dict:
+    """Return available configuration names found in ``llm_configs``."""
+
+    configs = []
+    if CONFIG_DIR.exists():
+        configs = [p.stem for p in CONFIG_DIR.glob("*.json")]
+    return {"configs": configs}
 

--- a/web_app/app.js
+++ b/web_app/app.js
@@ -2,7 +2,25 @@ const apiBase = 'http://localhost:8000';
 
 const audioInput = document.getElementById('audioFile');
 const audioPlayer = document.getElementById('audioPlayer');
+const configSelect = document.getElementById('configSelect');
 
+async function loadConfigs() {
+  if (!configSelect) return;
+  try {
+    const res = await fetch(`${apiBase}/configs`);
+    const data = await res.json();
+    data.configs.forEach((name) => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      configSelect.appendChild(opt);
+    });
+  } catch (err) {
+    console.error('Failed to load configs', err);
+  }
+}
+
+loadConfigs();
 audioInput.addEventListener('change', (e) => {
   const file = e.target.files[0];
   if (file) {
@@ -10,14 +28,14 @@ audioInput.addEventListener('change', (e) => {
   }
 });
 
-async function sendPrompt(prompt) {
+async function sendPrompt(prompt, config) {
   const respDiv = document.getElementById('response');
   respDiv.textContent = 'Loading...';
   try {
     const res = await fetch(`${apiBase}/complete`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt })
+      body: JSON.stringify({ prompt, config })
     });
     const data = await res.json();
     respDiv.textContent = data.text || JSON.stringify(data);
@@ -42,7 +60,8 @@ async function sendPrompt(prompt) {
 
 document.getElementById('sendText').addEventListener('click', async () => {
   const prompt = document.getElementById('prompt').value;
-  sendPrompt(prompt);
+  const config = document.getElementById('configSelect').value;
+  sendPrompt(prompt, config);
 });
 
 const voiceBtn = document.getElementById('startVoice');
@@ -58,7 +77,8 @@ if (voiceBtn) {
       const transcript = event.results[0][0].transcript;
       const promptInput = document.getElementById('prompt');
       promptInput.value = transcript;
-      sendPrompt(transcript);
+      const config = document.getElementById('configSelect').value;
+      sendPrompt(transcript, config);
     };
     recognition.start();
   });

--- a/web_app/index.html
+++ b/web_app/index.html
@@ -14,6 +14,8 @@
     <input type="file" id="audioFile" accept="audio/*" />
     <audio id="audioPlayer" controls></audio>
     <textarea id="prompt" placeholder="Ask a question"></textarea>
+    <label for="configSelect">Persona:</label>
+    <select id="configSelect"></select>
     <div>
       <button id="sendText">Send</button>
       <button id="startVoice">Speak</button>

--- a/web_app/style.css
+++ b/web_app/style.css
@@ -73,3 +73,18 @@ audio {
   margin-top: 0.5rem;
   width: 100%;
 }
+
+label {
+  margin-top: 1rem;
+  display: block;
+}
+
+select {
+  margin-top: 0.5rem;
+  width: 100%;
+  padding: 0.5rem;
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+  border: 1px solid #444;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- expose available LLM configs and allow selecting them per request
- proxy config parameter through API gateway
- add dropdown to web demo to choose a persona
- style dropdown and document new folder

## Testing
- `pip install -r services/api_gateway/requirements.txt -r services/context_service/requirements.txt -r services/llm_gateway/requirements.txt pgvector pytest | tail -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688692cf4e9c8333a40be305f94310b2