### PR TITLE
Fix llm_gateway path lookup error

### DIFF
--- a/services/llm_gateway/config.py
+++ b/services/llm_gateway/config.py
@@ -9,8 +9,12 @@ from typing import Any, Dict
 
 
 # Look for a global configuration file at the repository root.  Fall back to the
-# legacy local file if it doesn't exist.
-DEFAULT_ROOT_PATH = Path(__file__).resolve().parents[2] / "llm_config.json"
+# legacy local file if it doesn't exist.  When running inside a Docker image
+# the service directory may be located at ``/app`` which doesn't have enough
+# parent directories for ``parents[2]``.  Guard against ``IndexError`` so the
+# fallback path works correctly in that scenario.
+_parents = Path(__file__).resolve().parents
+DEFAULT_ROOT_PATH = (_parents[2] if len(_parents) > 2 else _parents[-1]) / "llm_config.json"
 DEFAULT_LOCAL_PATH = Path(__file__).with_name("config.json")
 
 

--- a/services/llm_gateway/main.py
+++ b/services/llm_gateway/main.py
@@ -31,8 +31,11 @@ cfg = load_config()
 prompt_options = cfg.get("prompt_options", {})
 base_preprompt = cfg.get("base_preprompt", "")
 
-# Directory containing additional LLM configuration JSON files
-CONFIG_DIR = Path(__file__).resolve().parents[2] / "llm_configs"
+# Directory containing additional LLM configuration JSON files. When the service
+# is packaged into a Docker image the path may be shorter (e.g. ``/app``), so we
+# gracefully handle the case where ``parents[2]`` would raise an ``IndexError``.
+_parents = Path(__file__).resolve().parents
+CONFIG_DIR = (_parents[2] if len(_parents) > 2 else _parents[-1]) / "llm_configs"
 
 genai.configure(api_key=cfg["api_key"])
 model = genai.GenerativeModel(cfg["model"])


### PR DESCRIPTION
## Summary
- prevent IndexError when resolving `llm_gateway` config path
- handle short parent paths in `main.py`

## Testing
- `pip install -q -r services/api_gateway/requirements.txt -r services/llm_gateway/requirements.txt -r services/context_service/requirements.txt -r services/tts_service/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886954ecfc48333ae76347df7d57cf0